### PR TITLE
Add Render deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,12 @@ To open this project in GitHub Codespaces, click the button below:
 To open this project in Gitpod, click the button below:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jpmorganchase/hugo-quickstart)
+
+## Render Deployment
+
+This project includes a `render.yaml` file to simplify deployment on [Render](https://render.com). This file creates a Blueprint that automatically configures the project as a static site.
+
+To deploy:
+1. Create a new [Blueprint Instance](https://dashboard.render.com/blueprints/new) on Render.
+2. Connect your repository.
+3. Render will automatically detect the `render.yaml` configuration and set up the build command (`hugo --gc --minify`) and publish directory (`website/public`).

--- a/render.yaml
+++ b/render.yaml
@@ -4,4 +4,5 @@ services:
     env: static
     root: website
     buildCommand: hugo --gc --minify
+    preDeployCommand: git submodule update --init --recursive
     staticPublishPath: public

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: hugo-quickstart
+    env: static
+    root: website
+    buildCommand: hugo --gc --minify
+    staticPublishPath: public


### PR DESCRIPTION
Added `render.yaml` configuration file to support automatic deployment of the Hugo site on Render as a static site.
Updated `README.md` to include a section explaining the Render deployment process.

---
*PR created automatically by Jules for task [318058695294814498](https://jules.google.com/task/318058695294814498) started by @xNok*