### PR TITLE
Remove ananke and add content

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -32,7 +32,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -85,7 +84,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           # Clone a Theme from a Private Repository
           # ssh-key: |
           #   ${{ secrets.SSH_PRIVATE_KEY_THEME }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "website/themes/ananke"]
-	path = website/themes/ananke
-	url = https://github.com/theNewDynamic/gohugo-theme-ananke.git

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Hugo Quickstart"
+---
+
+This repository provides a template for creating a Hugo-based static site, optimized for deployment as GitHub Pages. It offers a streamlined setup for developers to quickly launch a new website with minimal configuration. The structure includes a pre-configured `hugo.toml` file and essential directories, allowing you to focus on content creation from the start.
+
+This project is designed for seamless development in cloud-based environments. You can use it with Gitpod or GitHub Codespaces to get a ready-to-use development environment in seconds, without needing to install any dependencies on your local machine.
+
+## Key Features
+
+- **Quick Setup**: Clone the repository and start your Hugo site instantly.
+- **GitHub Pages Integration**: Pre-configured for easy deployment.
+- **Cloud-Ready**: Works out-of-the-box with Gitpod and GitHub Codespaces.
+- **Customizable**: Easily extendable with your own content and themes.
+
+This template is ideal for developers, bloggers, and content creators who want a fast and efficient way to build and deploy static websites using Hugo.

--- a/website/content/deployment.md
+++ b/website/content/deployment.md
@@ -1,0 +1,28 @@
+---
+title: "Deployment"
+---
+
+## Cloud-Based Development
+
+This repository is optimized for cloud-based development environments like Gitpod and GitHub Codespaces. These platforms provide a pre-configured environment with all the necessary dependencies, allowing you to start coding immediately.
+
+### GitHub Codespaces
+
+To open this project in GitHub Codespaces, click the button below:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=428059888)
+
+### Gitpod
+
+To open this project in Gitpod, click the button below:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jpmorganchase/hugo-quickstart)
+
+## Render Deployment
+
+This project includes a `render.yaml` file to simplify deployment on [Render](https://render.com). This file creates a Blueprint that automatically configures the project as a static site.
+
+To deploy:
+1. Create a new [Blueprint Instance](https://dashboard.render.com/blueprints/new) on Render.
+2. Connect your repository.
+3. Render will automatically detect the `render.yaml` configuration and set up the build command (`hugo --gc --minify`) and publish directory (`website/public`).

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -1,0 +1,21 @@
+---
+title: "Getting Started"
+---
+
+To get started with this template, you can use the following Hugo commands.
+
+### Running the Development Server
+
+To preview your site locally, run the following command. This will start a development server with live reloading, allowing you to see your changes in real-time.
+
+```bash
+hugo server
+```
+
+### Building the Static Site
+
+When you're ready to deploy your site, you can generate the static files using the following command. The output will be placed in the `public` directory by default.
+
+```bash
+hugo
+```

--- a/website/content/testing.md
+++ b/website/content/testing.md
@@ -1,0 +1,29 @@
+---
+title: "Testing"
+---
+
+This template includes Playwright end-to-end tests to verify that the site builds and runs correctly.
+
+### Running Tests
+
+To run the Playwright tests locally, you'll need to install Node.js dependencies first:
+
+```bash
+npm install
+```
+
+Then run the tests:
+
+```bash
+npm test
+```
+
+The tests will automatically start a Hugo development server, run the tests against it, and then shut it down.
+
+### Test Scripts
+
+- `npm test` - Run tests in headless mode (CI mode)
+- `npm run test:headed` - Run tests with visible browser
+- `npm run test:ui` - Run tests in interactive UI mode
+
+The tests run automatically in GitHub Actions on every pull request and push to main, ensuring the site works correctly before deployment.

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -6,3 +6,17 @@ theme = 'custom-theme'
 [caches]
   [caches.images]
     dir = ':cacheDir/images'
+[[menus.main]]
+  name = 'Getting Started'
+  pageRef = '/getting-started'
+  weight = 10
+
+[[menus.main]]
+  name = 'Testing'
+  pageRef = '/testing'
+  weight = 20
+
+[[menus.main]]
+  name = 'Deployment'
+  pageRef = '/deployment'
+  weight = 30

--- a/website/themes/custom-theme/layouts/index.html
+++ b/website/themes/custom-theme/layouts/index.html
@@ -1,16 +1,17 @@
 {{ define "main" }}
 <section class="hero">
-  <h1>Welcome to {{ .Site.Title }}</h1>
-  <p>{{ .Site.Params.description | default "A minimal Hugo starter theme." }}</p>
+  <h1>{{ .Title }}</h1>
+  <div class="content">
+    {{ .Content }}
+  </div>
 </section>
 
-<section class="latest-posts">
-  <h2>Latest Posts</h2>
+<section class="pages-list">
+  <h2>Pages</h2>
   <ul>
-    {{ range first 5 .Site.RegularPages }}
+    {{ range .Site.RegularPages }}
     <li>
       <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-      <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
     </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
I have removed the `ananke` submodule and created new content pages to self-document the repository.
Changes:
1.  Removed `website/themes/ananke` submodule and `.gitmodules`.
2.  Created `website/content` with:
    -   `_index.md`: Overview.
    -   `getting-started.md`: Setup instructions.
    -   `testing.md`: Testing instructions.
    -   `deployment.md`: Deployment instructions.
3.  Updated `website/hugo.toml` to include a navigation menu.
4.  Updated `website/themes/custom-theme/layouts/index.html` to display the homepage content.

I verified the file structure and content. I attempted to install Hugo to verify the build but the environment made it difficult (slow compilation, binary not found). I verified the code changes manually.

---
*PR created automatically by Jules for task [9745855639930797968](https://jules.google.com/task/9745855639930797968) started by @xNok*