### PR TITLE
Add Sanity Check Page and Educational Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.56.1"
+        "@playwright/test": "^1.56.1",
+        "hugo-extended": "^0.155.2"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -28,6 +42,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -41,6 +75,48 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hugo-extended": {
+      "version": "0.155.2",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.155.2.tgz",
+      "integrity": "sha512-H3A8ZOcPNODt118mFRa/VNc+fbckN5BP7uWvXXmgey4cQ5v18BUuvM3ll9MG2BKgEjflRkPPYbxNEuTq5f0+yA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "tar": "^7.5.7"
+      },
+      "bin": {
+        "hugo": "dist/cli.mjs",
+        "hugo-extended": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/playwright": {
@@ -71,6 +147,33 @@
       "bin": {
         "playwright-core": "cli.js"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.56.1",
-    "hugo-extended": "^0.155.2"
+    "hugo-extended": "0.136.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.56.1"
+    "@playwright/test": "^1.56.1",
+    "hugo-extended": "^0.155.2"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'cd website && hugo server',
+    command: 'npx hugo server -s website',
     url: 'http://localhost:1313',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -1,26 +1,44 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test.describe('Hugo Site Tests', () => {
-  test('homepage loads successfully', async ({ page }) => {
+/**
+ * This file contains End-to-End (E2E) tests for our Hugo website.
+ * We use Playwright to simulate a user interacting with the site.
+ *
+ * You can run these tests using: npm test
+ */
+
+test.describe('Website Sanity Checks', () => {
+
+  // Test 1: Verify the homepage loads and has the correct title
+  test('homepage has correct title', async ({ page }) => {
+    // 1. Navigate to the homepage ('/' refers to the baseURL set in playwright.config.js)
     await page.goto('/');
     
-    // Check that the page has loaded and contains the site title
+    // 2. Assert that the page title matches what we expect in hugo.toml
     await expect(page).toHaveTitle(/My New Hugo Site/);
   });
 
-  test('homepage has content', async ({ page }) => {
+  // Test 2: Verify that the content is visible
+  test('homepage shows main content', async ({ page }) => {
     await page.goto('/');
     
-    // Check that the page has some visible content
+    // Check that the body element is visible
     const body = page.locator('body');
     await expect(body).toBeVisible();
   });
 
-  test('navigation is accessible', async ({ page }) => {
-    await page.goto('/');
+  // Test 3: Verify the "Sanity Check" page exists
+  // This demonstrates how to test specific pages and their content.
+  test('sanity check page exists and loads', async ({ page }) => {
+    // Navigate to the newly created page
+    // Note: Hugo generates URLs based on the content filename.
+    // content/sanity-check.md becomes /sanity-check/
+    await page.goto('/sanity-check/');
     
-    // Check that basic HTML structure exists
-    await expect(page.locator('html')).toBeVisible();
+    // Check that the heading on the page is correct
+    // We look for an h1 element with the specific text
+    await expect(page.locator('h1')).toContainText('Sanity Check for your next Hugo deployment');
   });
+
 });

--- a/website/content/sanity-check.md
+++ b/website/content/sanity-check.md
@@ -28,7 +28,7 @@ You can run the tests locally to verify your changes before pushing them.
     ```
 
     This command (configured in `package.json`) will:
-    - Build your Hugo site.
+    - Start your Hugo site in development mode (using `hugo server`).
     - Start a local server.
     - Run the Playwright tests against that server.
 

--- a/website/content/sanity-check.md
+++ b/website/content/sanity-check.md
@@ -1,0 +1,44 @@
+---
+title: "Sanity Check for your next Hugo deployment"
+---
+
+## What is a Sanity Check?
+
+A sanity check is a basic test to quickly evaluate whether a claim or the result of a calculation can possibly be true. In software development, it serves as a "smoke test" to ensure that the critical functions of your application (or website) are working as expected before you dive into deeper testing or deployment.
+
+For a static website like this one, a sanity check might verify:
+1.  The homepage loads successfully.
+2.  Key pages (like this one!) are accessible.
+3.  The title and essential metadata are correct.
+4.  No broken links on the main navigation.
+
+## Automated Testing with Playwright
+
+This repository includes a set of automated End-to-End (E2E) tests using [Playwright](https://playwright.dev/). These tests simulate a real user opening a browser and interacting with your site.
+
+### How to Run the Tests
+
+You can run the tests locally to verify your changes before pushing them.
+
+1.  **Open your terminal.**
+2.  **Run the test command:**
+
+    ```bash
+    npm test
+    ```
+
+    This command (configured in `package.json`) will:
+    - Build your Hugo site.
+    - Start a local server.
+    - Run the Playwright tests against that server.
+
+3.  **Check the results:**
+    You will see output in the terminal indicating whether tests passed or failed.
+
+### Continuous Integration (CI)
+
+These tests are also configured to run automatically on GitHub Actions whenever you push code or create a pull request. This ensures that you don't accidentally break your site.
+
+## Example Test
+
+You can find the test definition in `tests/homepage.spec.js`. Open that file to see how we define what "success" looks like for this website. It's a great place to start learning how to write your own tests!


### PR DESCRIPTION
Added a new page 'Sanity Check for your next Hugo deployment' to the website.
Updated E2E tests in `tests/homepage.spec.js` to be more educational and include a test for the new page.
Updated `playwright.config.js` to reliably run `hugo server` using `npx`.
Added `hugo-extended` to `devDependencies` to ensure the environment works correctly.

---
*PR created automatically by Jules for task [920236747853616138](https://jules.google.com/task/920236747853616138) started by @xNok*