### PR TITLE
Upgrade Hugo to 0.155.2

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.136.0'
+          hugo-version: '0.155.2'
           extended: true
 
       - name: Setup Node.js
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.136.0'
+          hugo-version: '0.155.2'
           extended: true
 
       - name: Build with Hugo

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.56.1",
-        "hugo-extended": "^0.155.2"
+        "hugo-extended": "0.155.2"
       }
     },
     "node_modules/@isaacs/fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.56.1",
-    "hugo-extended": "0.136.0"
+    "hugo-extended": "0.155.2"
   }
 }


### PR DESCRIPTION
Updated `package.json` and `package-lock.json` to use `hugo-extended` v0.155.2.
Updated `.github/workflows/website.yaml` to use Hugo v0.155.2 in CI jobs.
Regenerated `package-lock.json` and ran `npm audit fix`.

---
*PR created automatically by Jules for task [15050643714027196664](https://jules.google.com/task/15050643714027196664) started by @xNok*